### PR TITLE
Rework encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/cilium/cilium v1.10.4
-	github.com/cilium/hubble v0.8.2 // indirect
-	github.com/cloudflare/cfssl v1.6.0 // indirect
+	github.com/cilium/hubble v0.8.2
+	github.com/cloudflare/cfssl v1.6.0
 	github.com/cloudflare/go-metrics v0.0.0-20151117154305-6a9aea36fb41 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/badger/v3 v3.2103.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/isovalent/mock-hubble v0.0.0-20210928133358-8a1660dd0897
 	github.com/open-telemetry/opentelemetry-collector-builder v0.33.0
 	github.com/prometheus/client_golang v1.11.0 // indirect
@@ -19,7 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/zmap/zlint v0.0.0-20190806154020-fd021b4cfbeb // indirect
 	go.opentelemetry.io/collector v0.33.0
-	go.opentelemetry.io/otel/sdk v1.0.0-RC3
+	go.opentelemetry.io/otel/sdk v1.0.0-RC3 // indirect
 	go.opentelemetry.io/otel/trace v1.0.0-RC3
 	go.opentelemetry.io/proto v0.9.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0

--- a/logconv/logconv.go
+++ b/logconv/logconv.go
@@ -14,10 +14,9 @@ type FlowConverter struct {
 	*common.FlowEncoder
 }
 
-func NewFlowConverter(encoding string, options common.EncodingOptions) *FlowConverter {
+func NewFlowConverter(options common.EncodingOptions) *FlowConverter {
 	return &FlowConverter{
 		FlowEncoder: &common.FlowEncoder{
-			Encoding:        encoding,
 			EncodingOptions: options,
 		},
 	}
@@ -59,7 +58,7 @@ func (c *FlowConverter) Convert(hubbleResp *observer.GetFlowsResponse) (protoref
 		}
 	} else {
 		logRecord.Attributes = append(logRecord.Attributes, &commonV1.KeyValue{
-			Key:   common.AttributeEventPayload,
+			Key:   common.AttributeEventObject,
 			Value: v,
 		})
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -199,7 +199,7 @@ func CheckResource(t *testing.T, res *resourceV1.Resource, hubbleResp *observer.
 	}
 }
 
-func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingFormat string, encodingOptions common.EncodingOptions) *commonV1.AnyValue {
+func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingOptions common.EncodingOptions) *commonV1.AnyValue {
 	t.Helper()
 
 	var payload *commonV1.AnyValue
@@ -220,7 +220,7 @@ func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingFormat st
 			}
 		case common.AttributeEventEncoding:
 			hasEncodingAttr = true
-			if attr.Value.GetStringValue() != encodingFormat {
+			if attr.Value.GetStringValue() != encodingOptions.Encoding {
 				t.Error("econding is wrong")
 			}
 		case common.AttributeEventEncodingOptions:
@@ -228,10 +228,10 @@ func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingFormat st
 			if attr.Value.GetStringValue() != encodingOptions.String() {
 				t.Error("econding options are wrong")
 			}
-		case common.AttributeEventPayload:
+		case common.AttributeEventObject:
 			payload = attr.Value
 		}
-		if strings.HasPrefix(attr.Key, common.AttributeEventPayloadMapPrefix) {
+		if strings.HasPrefix(attr.Key, common.AttributeFlowEventNamespace) {
 			if payload == nil {
 				payload = &commonV1.AnyValue{
 					Value: &commonV1.AnyValue_KvlistValue{
@@ -259,7 +259,7 @@ func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingFormat st
 	}
 	if encodingOptions.TopLevelKeys && !encodingOptions.LogPayloadAsBody {
 		if !hasPayloadInTopLevelKeys {
-			t.Error("missing payload keys")
+			t.Fatal("missing payload keys")
 		}
 		expectedLen = 3 + len(payload.GetKvlistValue().Values)
 	}

--- a/traceconv/traceconv.go
+++ b/traceconv/traceconv.go
@@ -21,7 +21,7 @@ type FlowConverter struct {
 	*common.FlowEncoder
 }
 
-func NewFlowConverter(attributeEncoding, dir string, options common.EncodingOptions) (*FlowConverter, error) {
+func NewFlowConverter(dir string, options common.EncodingOptions) (*FlowConverter, error) {
 	opt := badger.DefaultOptions(dir)
 	opt.Logger = nil // TODO: make this use hubble-otel logger
 	tc, err := NewTraceCache(opt)
@@ -31,7 +31,6 @@ func NewFlowConverter(attributeEncoding, dir string, options common.EncodingOpti
 
 	return &FlowConverter{
 		FlowEncoder: &common.FlowEncoder{
-			Encoding:        attributeEncoding,
 			EncodingOptions: options,
 		},
 		traceCache: tc,
@@ -77,7 +76,7 @@ func (c *FlowConverter) Convert(hubbleResp *hubbleObserver.GetFlowsResponse) (pr
 		}
 	} else {
 		span.Attributes = append(span.Attributes, &commonV1.KeyValue{
-			Key:   common.AttributeEventPayload,
+			Key:   common.AttributeEventObject,
 			Value: v,
 		})
 


### PR DESCRIPTION
- simplify attribute key naming (get rid of io. prefix, as it's
  something OpenTelemetry spec recommends, using simple cilium.
  namespace)
- make sure the spec is complied with by avoiding key collision
  between namespaces and standalone keys
- bump schema version
- rework `common.EncodingOptions`
- split `-logs.*` and `-trace.*` flags, as some of the encoding
  formats are actually only compatible with log data spec