### PR TITLE
Avoid re-building images on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,5 +64,5 @@ jobs:
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
           entrypoint: make
-          args: images.hubble-otel images.otelcol PUSH=true
+          args: images.hubble-otel images.otelcol PUSH=true WITHOUT_TAG_SUFFIX=true
 


### PR DESCRIPTION
The otelcol image takes 14m to build, and due to -dev suffix it
gets rebuilt on every run in CI. Broadly, the suffix is not critical
to CI, so disabling it shouldn't do any harm.