### PR TITLE
Use pointers to make sure flags are set as intended

### DIFF
--- a/logconv/logconv.go
+++ b/logconv/logconv.go
@@ -16,7 +16,11 @@ type FlowConverter struct {
 	*common.FlowEncoder
 }
 
-func NewFlowConverter(log *logrus.Logger, options common.EncodingOptions) *FlowConverter {
+func NewFlowConverter(log *logrus.Logger, options *common.EncodingOptions) *FlowConverter {
+	if log != nil {
+		log.WithField("options", options.String()).Debugf("logs converter created")
+	}
+
 	return &FlowConverter{
 		FlowEncoder: &common.FlowEncoder{
 			EncodingOptions: options,
@@ -37,7 +41,7 @@ func (c *FlowConverter) Convert(hubbleResp *observer.GetFlowsResponse) (protoref
 		TimeUnixNano: uint64(flow.GetTime().AsTime().UnixNano()),
 		Attributes: common.NewStringAttributes(map[string]string{
 			common.AttributeEventKindVersion:     common.AttributeEventKindVersionFlowV1alpha1,
-			common.AttributeEventEncoding:        c.Encoding,
+			common.AttributeEventEncoding:        c.EncodingFormat(),
 			common.AttributeEventEncodingOptions: c.EncodingOptions.String(),
 		}),
 	}
@@ -53,9 +57,9 @@ func (c *FlowConverter) Convert(hubbleResp *observer.GetFlowsResponse) (protoref
 		}},
 	}
 
-	if c.LogPayloadAsBody {
+	if c.WithLogPayloadAsBody() {
 		logRecord.Body = v
-	} else if c.TopLevelKeys {
+	} else if c.WithTopLevelKeys() {
 		for _, payloadAttribute := range v.GetKvlistValue().Values {
 			logRecord.Attributes = append(logRecord.Attributes, payloadAttribute)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -24,8 +24,11 @@ func TestBasicIntegrationWithTLS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	isFalse := false
-	isTrue := true
+	_false := new(bool)
+	*_false = false
+	_true := new(bool)
+	*_true = true
+
 	newString := func(s string) *string { return &s }
 
 	fatal := make(chan error, 1)
@@ -52,8 +55,8 @@ func TestBasicIntegrationWithTLS(t *testing.T) {
 	}()
 
 	commonFlagsTLS := &flagsTLS{
-		enable:               &isTrue,
-		insecureSkipVerify:   &isFalse,
+		enable:               _true,
+		insecureSkipVerify:   _false,
 		clientCertificate:    newString("testdata/certs/test-client.pem"),
 		clientKey:            newString("testdata/certs/test-client-key.pem"),
 		certificateAuthority: newString("testdata/certs/ca.pem"),
@@ -136,42 +139,42 @@ func TestBasicIntegrationWithTLS(t *testing.T) {
 		}
 	}
 
-	modes := map[string][]common.EncodingOptions{
+	modes := map[string][]*common.EncodingOptions{
 		// test option combinations that relevant to particular encoding
 		common.EncodingJSON: {
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: true},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _true},
 		},
 
 		common.EncodingJSONBASE64: {
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _false},
 		},
 
 		common.EncodingFlatStringMap: {
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: true},
-			{TopLevelKeys: true, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: true, LabelsAsMaps: true, LogPayloadAsBody: false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _true},
+			{TopLevelKeys: _true, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _true, LabelsAsMaps: _true, LogPayloadAsBody: _false},
 		},
 		common.EncodingSemiFlatTypedMap: {
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: true},
-			{TopLevelKeys: true, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: true, LabelsAsMaps: true, LogPayloadAsBody: false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _true},
+			{TopLevelKeys: _true, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _true, LabelsAsMaps: _true, LogPayloadAsBody: _false},
 		},
 		common.EncodingTypedMap: {
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: false},
-			{TopLevelKeys: false, LabelsAsMaps: false, LogPayloadAsBody: true},
-			{TopLevelKeys: false, LabelsAsMaps: true, LogPayloadAsBody: false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _false},
+			{TopLevelKeys: _false, LabelsAsMaps: _false, LogPayloadAsBody: _true},
+			{TopLevelKeys: _false, LabelsAsMaps: _true, LogPayloadAsBody: _false},
 		},
 	}
 
 	for k := range modes {
 		for i := range modes[k] {
 			options := modes[k][i]
-			options.Encoding = k
+			options.Encoding = &k
 
-			t.Run(options.Encoding+":"+options.String(), func(t *testing.T) {
+			t.Run(options.EncodingFormat()+":"+options.String(), func(t *testing.T) {
 				if err := run(log, flagsHubble, flagsOTLP, nil, true, true, 10, options, options); err != nil {
 					if testutil.IsEOF(err) {
 						checkCollectorMetrics(t, i)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -247,7 +247,7 @@ func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingOptions c
 			}
 		case common.AttributeEventEncoding:
 			hasEncodingAttr = true
-			if attr.Value.GetStringValue() != encodingOptions.Encoding {
+			if attr.Value.GetStringValue() != encodingOptions.EncodingFormat() {
 				t.Error("econding is wrong")
 			}
 		case common.AttributeEventEncodingOptions:
@@ -284,7 +284,7 @@ func CheckAttributes(t *testing.T, attrs []*commonV1.KeyValue, encodingOptions c
 	if payload != nil {
 		expectedLen = 4
 	}
-	if encodingOptions.TopLevelKeys && !encodingOptions.LogPayloadAsBody {
+	if encodingOptions.WithTopLevelKeys() && !encodingOptions.WithLogPayloadAsBody() {
 		if !hasPayloadInTopLevelKeys {
 			t.Fatal("missing payload keys")
 		}


### PR DESCRIPTION
It turns out that `foo := *(flag.Bool("foo", true, "set foo"))` will
always be set to the default value. This might be compiiler optimisation
or a special behaviour of flag package, it's kind of a mistery to me.