### PR TITLE
Fix separator for top-level keys

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -301,3 +301,19 @@ func parseLabel(label string) (string, string, error) {
 		return "", "", fmt.Errorf("cannot parse label %q, as it's not in \"k=v\" format", label)
 	}
 }
+
+func fmtKeyPath(keyPathPrefix, fieldName string, separator rune) string {
+	// NB: this format assumes that field names don't contain dots or other charcters,
+	// which is safe for *flow.Flow, so it's easier to query data as it doesn't
+	// result in `[` and `\"` characters being used in the keys; i.e. it's only "IP.source"
+	// and not "[\"IP\"][\"source\"]" (which would be less pressumptions, yet harder to
+	// query for the user)
+	switch keyPathPrefix {
+	case "":
+		return fieldName
+	case AttributeFlowEventNamespace:
+		return keyPathPrefix + string(separator) + fieldName
+	default:
+		return keyPathPrefix + string(separator) + fieldName
+	}
+}

--- a/common/mapbuilder_typedmap.go
+++ b/common/mapbuilder_typedmap.go
@@ -39,19 +39,3 @@ func (l *typedMap) newLeaf(_ string) leafer {
 		return true
 	}
 }
-
-func fmtKeyPath(keyPathPrefix, fieldName string, separator rune) string {
-	// NB: this format assumes that field names don't contain dots or other charcters,
-	// which is safe for *flow.Flow, so it's easier to query data as it doesn't
-	// result in `[` and `\"` characters being used in the keys; i.e. it's only "IP.source"
-	// and not "[\"IP\"][\"source\"]" (which would be less pressumptions, yet harder to
-	// query for the user)
-	switch keyPathPrefix {
-	case "":
-		return fieldName
-	case AttributeFlowEventNamespace:
-		return keyPathPrefix + fieldName
-	default:
-		return keyPathPrefix + string(separator) + fieldName
-	}
-}


### PR DESCRIPTION
Also move `fmtKeyPath` back to `common.go`, as it belongs there.