### PR TITLE
Store header values in lists to match OpenTelemtry spec

### DIFF
--- a/common/attributes_http_test.go
+++ b/common/attributes_http_test.go
@@ -76,17 +76,9 @@ func TestHTTPAttributes(t *testing.T) {
 					} else {
 						switch l7.Type {
 						case flowV1.L7FlowType_REQUEST:
-							if v, ok := result["http.request.header."+k]; !ok {
-								t.Errorf("request header %q is missing", header.Key)
-							} else if v.(string) != header.Value {
-								t.Errorf("value of request header %q doesn't match value of corresponding attribute (expected: %q, have: %v)", header.Key, header.Value, v)
-							}
+							checkHeader(t, "http.request.header."+k, header.Value, result)
 						case flowV1.L7FlowType_RESPONSE:
-							if v, ok := result["http.response.header."+k]; !ok {
-								t.Errorf("response header %q is missing", header.Key)
-							} else if v.(string) != header.Value {
-								t.Errorf("value of response header %q doesn't match value of corresponding attribute (expected: %q, have: %v)", header.Key, header.Value, v)
-							}
+							checkHeader(t, "http.response.header."+k, header.Value, result)
 						default:
 							t.Error("unexpected L7 type")
 						}
@@ -105,5 +97,23 @@ func TestHTTPAttributes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func checkHeader(t *testing.T, k, v string, result map[string]interface{}) {
+	if values, ok := result[k]; !ok {
+		t.Errorf("%q is missing", k)
+	} else if values, ok := values.([]interface{}); ok {
+		found := false
+		for i := range values {
+			if values[i].(string) == v {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("value of %q doesn't contain expected value (expected: %q, have: %v)", k, v, values)
+		}
+	} else {
+		t.Errorf("value of %q is not a list", k)
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -327,20 +327,20 @@ func MarshalJSON(m proto.Message) ([]byte, error) {
 	return jsonMarshaller.Marshal(m)
 }
 
-func parseLabel(v protoreflect.Value) (string, string, error) {
+func parseLabel(v protoreflect.Value) (string, *commonV1.AnyValue, error) {
 	label := v.String()
 	parts := strings.Split(label, "=")
 	switch len(parts) {
 	case 2:
-		return parts[0], parts[1], nil
+		return parts[0], newStringValue(parts[1]), nil
 	case 1:
-		return parts[0], "", nil
+		return parts[0], newStringValue(""), nil
 	default:
-		return "", "", fmt.Errorf("cannot parse label %q, as it's not in \"k=v\" format", label)
+		return "", nil, fmt.Errorf("cannot parse label %q, as it's not in \"k=v\" format", label)
 	}
 }
 
-func parseHeader(v protoreflect.Value) (string, string, error) {
+func parseHeader(v protoreflect.Value) (string, *commonV1.AnyValue, error) {
 	headerKey := ""
 	headerValue := ""
 	v.Message().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
@@ -353,11 +353,10 @@ func parseHeader(v protoreflect.Value) (string, string, error) {
 		return true
 	})
 	if headerKey == "" {
-		return "", "", fmt.Errorf("cannot use empty header key")
+		return "", nil, fmt.Errorf("cannot use empty header key")
 	}
-	return headerKey, headerValue, nil
+	return headerKey, newStringArrayValue(headerValue), nil
 }
-
 func fmtKeyPath(keyPathPrefix, fieldName string, separator rune) string {
 	// NB: this format assumes that field names don't contain dots or other charcters,
 	// which is safe for *flow.Flow, so it's easier to query data as it doesn't

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -412,16 +412,16 @@ func checkFlatEncodingForHTTPFlows(t *testing.T, encodingOptions *common.Encodin
 	if encodingOptions.WithHeadersAsMaps() {
 		if isResponse {
 			if accept, ok := result[resolveKey("l7.http.headers.accept", encodingOptions)]; ok {
-				if _, ok := accept.(string); !ok {
-					t.Errorf("header value is %T, should be a strings", accept)
+				if _, ok := accept.([]interface{}); !ok {
+					t.Errorf("header value is %T, should be a list", accept)
 				}
 			} else {
 				t.Errorf("accept header missing")
 			}
 		} else {
 			if userAgent, ok := result[resolveKey("l7.http.headers.user_agent", encodingOptions)]; ok {
-				if _, ok := userAgent.(string); !ok {
-					t.Errorf("header value is %T, should be a strings", userAgent)
+				if _, ok := userAgent.([]interface{}); !ok {
+					t.Errorf("header value is %T, should be a list", userAgent)
 				}
 			} else {
 				t.Errorf("user_agent header missing")

--- a/common/value_helpers.go
+++ b/common/value_helpers.go
@@ -26,6 +26,20 @@ func newStringValue(s string) *commonV1.AnyValue {
 	}
 }
 
+func newStringArrayValue(s ...string) *commonV1.AnyValue {
+	array := []*commonV1.AnyValue{}
+	for _, v := range s {
+		array = append(array, newStringValue(v))
+	}
+	return &commonV1.AnyValue{
+		Value: &commonV1.AnyValue_ArrayValue{
+			ArrayValue: &commonV1.ArrayValue{
+				Values: array,
+			},
+		},
+	}
+}
+
 func toList(labelsAsMaps, headersAsMaps bool, fd protoreflect.FieldDescriptor, v protoreflect.Value, mb mapBuilder, newLeafKeyPrefix string) *commonV1.ArrayValue {
 	items := v.List()
 	list := &commonV1.ArrayValue{
@@ -39,7 +53,7 @@ func toList(labelsAsMaps, headersAsMaps bool, fd protoreflect.FieldDescriptor, v
 	return list
 }
 
-func listToMap(v protoreflect.Value, converter func(v protoreflect.Value) (string, string, error)) *commonV1.AnyValue {
+func listToMap(v protoreflect.Value, converter func(v protoreflect.Value) (string, *commonV1.AnyValue, error)) *commonV1.AnyValue {
 	items := v.List()
 	m := &commonV1.KeyValueList{
 		Values: make([]*commonV1.KeyValue, items.Len()),
@@ -51,7 +65,7 @@ func listToMap(v protoreflect.Value, converter func(v protoreflect.Value) (strin
 		}
 		m.Values[i] = &commonV1.KeyValue{
 			Key:   k,
-			Value: newStringValue(v),
+			Value: v,
 		}
 	}
 	return &commonV1.AnyValue{


### PR DESCRIPTION
Duplicate HTTP headers are not disallowed, this has been overlooked
earlier. Also, OpenTelemtry spec dictates that value of `http.*.headers`
attributes should be lists of strings.

This is a follow-up to #31 