### PR TITLE
Ensure that `SemiFlatMap` flattens labels

### DIFF
--- a/common/mapbuilder_semiflattypedmap.go
+++ b/common/mapbuilder_semiflattypedmap.go
@@ -61,6 +61,12 @@ func (l *semiFlatTypedMap) newLeaf(keyPathPrefix string) leafer {
 			}
 		default:
 			if item := newValue(true, l.labelsAsMaps, l.headersAsMaps, fd, v, nil, ""); item != nil {
+				if l.labelsAsMaps && fd.FullName() == "flow.Endpoint.labels" {
+					// flatten labels into the main list instead of appending as a new list
+					for _, label := range item.GetKvlistValue().GetValues() {
+						l.append(fmtKeyPath(keyPath, label.Key, l.separator), label.Value)
+					}
+				}
 				l.append(keyPath, item)
 			}
 		}


### PR DESCRIPTION
This commit fixes flattening of labels (when turned into a map).
With labels in a nested map it's not possible to search traces by
label.

Close #54 