### PR TITLE
Do not use HTTP response latency to set end time of response span

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           CGO_ENABLED: "0"
         with:
           entrypoint: sh
-          args: -x -c "for dir in ./ ./receiver ; do cd $dir ; go vet ./... && go test ./... ; done"
+          args: -e -x -c "for dir in ./ ./receiver ; do cd $dir ; go vet ./... && go test ./... ; done"
       - uses: docker://docker.io/library/golang:1.17.1-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
         name: Ensure main package is functional
         env:

--- a/logs/converter.go
+++ b/logs/converter.go
@@ -65,9 +65,7 @@ func (c *FlowConverter) Convert(hubbleResp *observer.GetFlowsResponse) (protoref
 	if c.WithLogPayloadAsBody() {
 		logRecord.Body = v
 	} else if c.WithTopLevelKeys() {
-		for _, payloadAttribute := range v.GetKvlistValue().Values {
-			logRecord.Attributes = append(logRecord.Attributes, payloadAttribute)
-		}
+		logRecord.Attributes = append(logRecord.Attributes, v.GetKvlistValue().Values...)
 	} else {
 		logRecord.Attributes = append(logRecord.Attributes, &commonV1.KeyValue{
 			Key:   common.AttributeEventObject,

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -196,34 +196,30 @@ func GetMetricFamilies(ctx context.Context, t *testing.T, url string) map[string
 	}
 }
 
-func CheckCounterMetricIsZero(t *testing.T, families map[string]*promdto.MetricFamily, metrics ...string) {
-	t.Helper()
-
+func CheckCounterMetricIsZero(families map[string]*promdto.MetricFamily, metrics ...string) error {
 	for _, k := range metrics {
 		m, ok := families[k]
 		if !ok || len(m.GetMetric()) == 0 {
-			t.Errorf("metric %q should be present", k)
-			continue
+			return fmt.Errorf("metric %q should be present", k)
 		}
 		if v := m.GetMetric()[0].Counter.Value; *v != 0.0 {
-			t.Errorf("metric %q should be zero", k)
+			return fmt.Errorf("metric %q should be zero", k)
 		}
 	}
+	return nil
 }
 
-func CheckCounterMetricIsGreaterThen(t *testing.T, value float64, families map[string]*promdto.MetricFamily, metrics ...string) {
-	t.Helper()
-
+func CheckCounterMetricIsGreaterThen(value float64, families map[string]*promdto.MetricFamily, metrics ...string) error {
 	for _, k := range metrics {
 		m, ok := families[k]
 		if !ok || len(m.GetMetric()) == 0 {
-			t.Errorf("metric %q should be present", k)
-			continue
+			return fmt.Errorf("metric %q should be present", k)
 		}
 		if v := m.GetMetric()[0].Counter.Value; *v < value {
-			t.Errorf("metric %q should be at least %f, not %f", k, value, *v)
+			return fmt.Errorf("metric %q should be at least %f, not %f", k, value, *v)
 		}
 	}
+	return nil
 }
 
 func IsEOF(err error) bool {

--- a/trace/converter.go
+++ b/trace/converter.go
@@ -113,9 +113,6 @@ func (c *FlowConverter) Convert(hubbleResp *hubbleObserver.GetFlowsResponse) (pr
 		case flowV1.L7FlowType_RESPONSE:
 			span.Kind = traceV1.Span_SPAN_KIND_SERVER
 		}
-
-		span.EndTimeUnixNano = uint64(tsAsTime.Add(time.Duration(int64(l7.LatencyNs))).UnixNano())
-
 		span.Attributes = append(span.Attributes, common.GetHTTPAttributes(l7)...)
 	}
 


### PR DESCRIPTION
Due to the fact that response and request generate separate spans,
it's not currently possible to use HTTP latency as observed in the
L7 HTTP flows. Perhaps, a single request+response should generate
a single span, but that's not feasible until deeper flow tracking
can be implemented.

Fixes #68