### PR TITLE
Rework linkage to traces parsed from headers

### DIFF
--- a/trace/idgen_test.go
+++ b/trace/idgen_test.go
@@ -61,10 +61,10 @@ func TestTraceCache(t *testing.T) {
 
 	t.Logf("%d traces, %d spans", len(traces), len(spans))
 
-	if l, e := len(traces), 4052; l != e {
+	if l, e := len(traces), 4083; l != e {
 		t.Errorf("unexpected number of traces generated (have: %d, expected %d)", l, e)
 	}
-	if l, e := nonUniqueSpans, 141; l != e {
+	if l, e := nonUniqueSpans, 0; l != e {
 		t.Errorf("unexpected number of non-unique spans (have: %d, expected %d)", l, e)
 	}
 	if l, e := len(spans), totalFlows-nonUniqueSpans; l != e {


### PR DESCRIPTION
It turned out that linked spans cannot easily be extracted by the
functions that the SDK currently offers, e.g. `SpanContext` does
not even contain the ID of the parent span.
And the logic that was implemented up until now was doing it all
wrong and ended-up linking each trace ID that it parsed back to
itself (see #69).
With the need for smarter linking in mind (#70), it appears that
actually the right thing to do is to keep generating new traces
for HTTP flows, however link to existing spans whenever tracing
headers are present.

Fixes #69 
Fixes #70