### PR TITLE
Implement linking for HTTP flows

### DIFF
--- a/trace/idgen_test.go
+++ b/trace/idgen_test.go
@@ -70,7 +70,7 @@ func TestTraceCache(t *testing.T) {
 	if l, e := len(spans), totalFlows-nonUniqueSpans; l != e {
 		t.Errorf("unexpected number of spans generated (have: %d, expected %d)", l, e)
 	}
-	if l, e := len(linkedSpans), 34; l != e {
+	if l, e := len(linkedSpans), 342; l != e {
 		t.Errorf("unexpected number of parent spans (have: %d, expected %d)", l, e)
 	}
 }


### PR DESCRIPTION
Envoy already injects `x-request-id` header that is used for aggregation
[functionality in Hubble](https://github.com/cilium/cilium/blob/v1.10.5/pkg/hubble/parser/seven/parser.go#L157-L188).

