### PR TITLE
Pr/welan/fix deployment

### DIFF
--- a/USER_GUIDE_KIND.md
+++ b/USER_GUIDE_KIND.md
@@ -116,7 +116,7 @@ spec:
     - name: NODE_NAME
       valueFrom:
         fieldRef:
-          fieldPath: spec.nodeName
+          fieldPath: status.hostIP
   volumes:
     # this example connect to Hubble socket of Cilium agent
     # using host port and TLS

--- a/USER_GUIDE_KIND.md
+++ b/USER_GUIDE_KIND.md
@@ -14,7 +14,7 @@ to collect app traces. Second `OpenTelemetryCollector` will deploy upstream Open
 to run as sidecars of the demo app.
 
 The demo app used is [podinfo](https://github.com/stefanprodan/podinfo), it's instrumented using
-OpenTemetry SDK. There is a frontend service as well as backend which are going to be configured
+OpenTelemetry SDK. There is a frontend and backend configured
 to echo a simple playload, mimicking a common web app architecture.
 
 Having followed through this guide, you will understand the value of insights into network-level
@@ -46,7 +46,7 @@ EOF
 kind create cluster --config kind-config.yaml
 ```
 
-Install Cilim with Hubble enabled:
+Install Cilium with Hubble enabled:
 ```
 cilium install && cilium hubble enable
 ```
@@ -282,7 +282,7 @@ kubectl apply -f visibility-policies.yaml
 
 The podinfo app is instrumented with OpenTelemetry SDK, one way to export the traces is by using collector sidecar.
 
-Add sidecard config:
+Add sidecar config:
 ```
 cat > otelcol-podinfo.yaml << EOF
 apiVersion: opentelemetry.io/v1alpha1


### PR DESCRIPTION
prefer node ip for commnunicating with cilium , rather than DNS


when I deploy hubble-otel , I encounter the following issue reported by the hubble otel collector
it failed to resolve Node DNS . 
It much make sense to use nodeIp for collector communicating directly with cilium-agent for most cases

```
# kubectl logs -n kube-system -l app.kubernetes.io/name=otelcol-hubble-collector
2022-01-27T13:22:38.295Z	info	v3@v3.2103.1/logger.go:46	Discard stats nextEmptySlot: 0
	{"kind": "receiver", "name": "hubble"}
2022-01-27T13:22:38.295Z	info	v3@v3.2103.1/logger.go:46	Set nextTxnTs to 0	{"kind": "receiver", "name": "hubble"}
2022-01-27T13:22:38.298Z	info	service/telemetry.go:116	Serving Prometheus metrics	{"address": ":8888", "level": "basic", "service.instance.id": "cae4e6c1-bbca-41f6-93b6-7d9e0c310551", "service.version": "latest"}
2022-01-27T13:22:38.298Z	info	service/collector.go:230	Starting otelcol-hubble...	{"Version": "0.1.0", "NumCPU": 40}
2022-01-27T13:22:38.298Z	info	service/collector.go:132	Everything is ready. Begin running and processing data.
2022-01-27T13:22:39.282Z	info	jaegerexporter@v0.38.0/exporter.go:186	State of the connection with the Jaeger Collector backend	{"kind": "exporter", "name": "jaeger", "state": "READY"}
2022-01-27T13:22:42.290Z	error	receiver@v0.0.0-00010101000000-000000000000/receiver.go:94	hubble reciever error	{"kind": "receiver", "name": "hubble", "error": "GetFlows failed: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: lookup 172-81-0-20 on 172.22.0.10:53: server misbehaving\""}
github.com/cilium/hubble-otel/receiver.(*hubbleReceiver).Start.func1
	github.com/cilium/hubble-otel/receiver@v0.0.0-00010101000000-000000000000/receiver.go:94
2022-01-27T13:22:38.600Z	info	v3@v3.2103.1/logger.go:46	Discard stats nextEmptySlot: 0
	{"kind": "receiver", "name": "hubble"}
2022-01-27T13:22:38.600Z	info	v3@v3.2103.1/logger.go:46	Set nextTxnTs to 0	{"kind": "receiver", "name": "hubble"}
2022-01-27T13:22:38.606Z	info	service/telemetry.go:116	Serving Prometheus metrics	{"address": ":8888", "level": "basic", "service.instance.id": "b597c5cb-2d86-4173-a8b1-0a5fecfd3635", "service.version": "latest"}
2022-01-27T13:22:38.606Z	info	service/collector.go:230	Starting otelcol-hubble...	{"Version": "0.1.0", "NumCPU": 40}
2022-01-27T13:22:38.606Z	info	service/collector.go:132	Everything is ready. Begin running and processing data.
2022-01-27T13:22:39.590Z	info	jaegerexporter@v0.38.0/exporter.go:186	State of the connection with the Jaeger Collector backend	{"kind": "exporter", "name": "jaeger", "state": "READY"}
2022-01-27T13:22:42.593Z	error	receiver@v0.0.0-00010101000000-000000000000/receiver.go:94	hubble reciever error	{"kind": "receiver", "name": "hubble", "error": "GetFlows failed: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: lookup 172-81-0-10 on 172.22.0.10:53: server misbehaving\""}
github.com/cilium/hubble-otel/receiver.(*hubbleReceiver).Start.func1
	github.com/cilium/hubble-otel/receiver@v0.0.0-00010101000000-000000000000/receiver.go:94
```




Signed-off-by: weizhou Lan weizhou.lan@daocloud.io
