### PR TITLE
Add configuration to run against local mock

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -71,6 +71,12 @@ This script will run `mock-hubble` with a set of sample flows from `testdata` di
 as 10x the rate stored in the sample file. The sample file simply contains output of `hubble observe -o json -f`
 and can be updated easily.
 
+To connect to the mock, use `with-mock.yaml` configuration:
+
+```
+./dev-scripts/run-otelcol.sh --config dev-scripts/with-mock.yaml
+```
+
 ## Running `hubble-otel` (standalone)
 
 To start Hubble adaptor in standalone mode against a local collector, run:

--- a/dev-scripts/with-mock.yaml
+++ b/dev-scripts/with-mock.yaml
@@ -1,0 +1,24 @@
+receivers:
+  hubble:
+    endpoint: http://localhost:4245 # unix:///var/run/cilium/hubble.sock
+    buffer_size: 10
+    include_flow_types:
+      traces: ["trace"]
+    tls:
+      insecure: true
+
+processors:
+  batch:
+    timeout: 30s
+    send_batch_size: 20
+
+exporters:
+  logging:
+    loglevel: debug
+
+service:
+  pipelines:
+    traces:
+      receivers: [hubble]
+      processors: [batch]
+      exporters: [logging]


### PR DESCRIPTION
It makes it easy to run `hubble-otel` locally without any cluster.